### PR TITLE
Fix incorrect iOS version in Features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A Swift package providing customizable modifiers for easy liquid glass effects a
 ## Features
 
 - **Glass Card Effects**: Beautiful glass cards with adaptive transparency that respond to light/dark mode
-- **Advanced Glass Effects**: Fine-grained control over glass appearance with tinting and corner radius options  
-- **Cross-Platform Support**: Works on iOS 26.0+ with graceful fallbacks for older versions
+- **Advanced Glass Effects**: Fine-grained control over glass appearance with tinting and corner radius options
+- **Cross-Platform Support**: Works on iOS 16.0+ with graceful fallbacks for older versions
 - **SwiftUI Integration**: Drop-in modifiers that work seamlessly with your existing SwiftUI views
 
 ## Support


### PR DESCRIPTION
This PR fixes an incorrect iOS version number in the README's Features section.

## Issue
The "Cross-Platform Support" feature stated the package "Works on iOS 26.0+", which is incorrect since iOS 26 has not been released yet.

## Fix
Changed "iOS 26.0+" to "iOS 16.0+" to match the actual minimum version requirement as correctly stated in the Requirements section below.

## Context
The package uses iOS 16.0+ as its base deployment target (as seen in Package.swift), with optional availability checks for future iOS 26 features when they become available. The Features section now correctly reflects this.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>