### PR TITLE
[codex] Fix ambiguous glass effect overload

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,5 +20,8 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "LiquidGlasKit"),
+        .testTarget(
+            name: "LiquidGlasKitTests",
+            dependencies: ["LiquidGlasKit"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -59,9 +59,23 @@ Text("Custom Glass Card")
 Apply advanced glass effects with full control over appearance:
 
 ```swift
+Text("Default Glass")
+    .padding()
+    .applyGlassEffect()
+```
+
+```swift
 Rectangle()
     .frame(width: 200, height: 100)
     .applyGlassEffect(.regularInteractive, cornerRadius: 12, tint: .blue)
+```
+
+Use `shape:` when you want a specific glass shape:
+
+```swift
+Text("Capsule Glass")
+    .padding()
+    .applyGlassEffect(.clearInteractive, shape: .capsule)
 ```
 
 Available glass effect types:

--- a/Sources/LiquidGlasKit/GlassEffect.swift
+++ b/Sources/LiquidGlasKit/GlassEffect.swift
@@ -168,10 +168,10 @@ public extension View {
     ///
     /// - Parameters:
     ///   - effect: The type of glass effect to apply. Defaults to `.clearInteractive`.
-    ///   - shape: The shape to apply to the glass effect. If `nil`, no specific shape is applied.
+    ///   - shape: The shape to apply to the glass effect. Pass `nil` to apply no specific shape.
     ///   - tint: An optional tint color. If `nil`, no tint is applied.
     /// - Returns: A view with the specified glass effect applied.
-    func applyGlassEffect(_ effect: GlassEffect = .clearInteractive, shape: GlassShape? = nil, tint: Color? = nil) -> some View {
+    func applyGlassEffect(_ effect: GlassEffect = .clearInteractive, shape: GlassShape?, tint: Color? = nil) -> some View {
         return modifier(GlassEffectModifier(effect: effect, shape: shape, tint: tint))
     }
 }

--- a/Tests/LiquidGlasKitTests/GlassEffectCompileTests.swift
+++ b/Tests/LiquidGlasKitTests/GlassEffectCompileTests.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import Testing
+@testable import LiquidGlasKit
+
+@MainActor
+@Test func applyGlassEffectOverloadsCompile() {
+    _ = Text("Default glass").applyGlassEffect()
+    _ = Text("Tinted glass").applyGlassEffect(tint: .blue)
+    _ = Text("Rounded glass").applyGlassEffect(.regularInteractive, cornerRadius: 12, tint: .blue)
+    _ = Text("Capsule glass").applyGlassEffect(.clearInteractive, shape: .capsule, tint: .blue)
+    _ = Text("Explicit no shape").applyGlassEffect(.regular, shape: nil)
+}


### PR DESCRIPTION
## Summary
- remove the default value from the shape-specific `applyGlassEffect` overload so `.applyGlassEffect()` resolves unambiguously
- add a focused Swift Testing compile guard for the flagship call and labeled overloads
- document the default call and shape-specific usage in the README

## Validation
- `swift build`
- `swift test`